### PR TITLE
Prepare repo for public release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files — Whizzlefred is the default reviewer and approver for every PR
+* @Whizzlefred

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,9 @@
 # Test artifacts
 test-options.json
 
+# Environment files (may contain credentials or local IPs)
+.env
+.env.*
+
 # Alloy runtime data (generated inside container, not in repo)
 data/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Whizzlefred
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/alloy/Dockerfile
+++ b/alloy/Dockerfile
@@ -25,7 +25,6 @@ RUN set -eux; \
 
 COPY rootfs /
 
-ARG BUILD_DATE
 ARG BUILD_VERSION
 LABEL \
     io.hass.name="Grafana Alloy" \

--- a/alloy/rootfs/etc/s6-overlay/s6-rc.d/init-alloy/run
+++ b/alloy/rootfs/etc/s6-overlay/s6-rc.d/init-alloy/run
@@ -78,7 +78,7 @@ loki.relabel "journal" {
     target_label  = "hostname"
   }
   rule {
-    source_labels = ["__journal_syslog_identifier"]
+    source_labels = ["__journal__SYSLOG_IDENTIFIER"]
     target_label  = "syslog_identifier"
   }
   rule {
@@ -86,11 +86,11 @@ loki.relabel "journal" {
     target_label  = "transport"
   }
   rule {
-    source_labels = ["__journal_container_name"]
+    source_labels = ["__journal__CONTAINER_NAME"]
     target_label  = "container_name"
   }
   rule {
-    source_labels = ["__journal_priority_keyword"]
+    source_labels = ["__journal__PRIORITY_KEYWORD"]
     target_label  = "level"
   }
 }


### PR DESCRIPTION
## Summary

- Add MIT `LICENSE` file (README declared MIT but no file existed)
- Add `.github/CODEOWNERS` — `@Whizzlefred` as default reviewer on all PRs
- Fix Alloy journal relabel rules: three source labels used wrong format (`__journal_<field>` with single underscore and lowercase) — corrected to `__journal__SYSLOG_IDENTIFIER`, `__journal__CONTAINER_NAME`, `__journal__PRIORITY_KEYWORD`
- Remove unused `BUILD_DATE` ARG from Dockerfile
- Add `.env` / `.env.*` patterns to `.gitignore`

## Note on history

The private home network IP (`192.168.178.16`) was scrubbed from all commits via `git filter-repo` and a force-push to `main` was done before this branch was created. This branch contains only the working-tree fixes.