### PR TITLE
Add ca_cert_file option for custom CA certificate support

### DIFF
--- a/alloy/CHANGELOG.md
+++ b/alloy/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.0
+
+- Add `ca_cert_file` option for custom CA certificate support (Closes #7)
+- Add `ssl:ro` volume mapping for `/ssl/` directory access
+
 ## 1.0.1
 
 - Fix: correct journal field names in relabel rules (`syslog_identifier`, `container_name`)

--- a/alloy/DOCS.md
+++ b/alloy/DOCS.md
@@ -18,6 +18,8 @@ changes.
 
 - **log_level**: Alloy log verbosity (`debug`, `info`, `warn`, `error`).
   Default: `info`
+- **ca_cert_file**: Path to a custom CA certificate file for TLS connections
+  to Loki (e.g., `/ssl/my-ca.crt`). See [TLS / Custom CA Certificates](#tls--custom-ca-certificates) below.
 - **additional_config**: Extra Alloy config blocks to append (advanced users)
 
 ## Labels
@@ -37,6 +39,29 @@ All journal entries are shipped to Loki with these labels:
 | `transport`        | journal transport type                    |
 | `container_name`   | Docker container name (for add-ons)       |
 | `level`            | log priority (debug, info, warning, etc.) |
+
+## TLS / Custom CA Certificates
+
+If your Loki instance uses TLS with a private or internal CA (e.g., step-ca,
+self-signed), Alloy will reject the certificate by default. Use the
+`ca_cert_file` option to provide your CA certificate.
+
+### Setup
+
+1. Copy your CA certificate (PEM format) to the Home Assistant `/ssl/`
+   directory. You can use the File Editor add-on, Samba share, or SSH.
+
+2. Set the add-on option to the certificate path:
+
+   ```yaml
+   loki_url: https://loki.example.com:3100/loki/api/v1/push
+   ca_cert_file: /ssl/my-ca.crt
+   ```
+
+3. Restart the add-on.
+
+A single PEM file can contain multiple CA certificates if you need to trust
+more than one CA.
 
 ## Debug UI
 
@@ -75,6 +100,9 @@ prevent Alloy from starting.
 - **Journal path not found**: The add-on auto-detects `/var/log/journal` or
   `/run/log/journal`. If neither exists, ensure `journald: true` is set in
   the add-on config (it is by default).
+- **TLS handshake errors / logs not arriving over HTTPS**: If your Loki
+  instance uses a private CA, set `ca_cert_file` to the path of your CA
+  certificate (e.g., `/ssl/my-ca.crt`). Ensure the file is in PEM format.
 
 ## Support
 

--- a/alloy/config.yaml
+++ b/alloy/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Grafana Alloy
-version: "1.0.1"
+version: "1.1.0"
 slug: alloy
 description: >-
   Ship Home Assistant OS systemd journal logs to Loki using Grafana Alloy.
@@ -17,6 +17,7 @@ boot: auto
 journald: true
 map:
   - addon_config:rw
+  - ssl:ro
 ports:
   12345/tcp: 12345
 ports_description:
@@ -25,9 +26,11 @@ watchdog: "http://[HOST]:[PORT:12345]/-/ready"
 options:
   loki_url: "http://localhost:3100/loki/api/v1/push"
   log_level: info
+  ca_cert_file: ""
 schema:
   loki_url: url
   log_level: "list(debug|info|warn|error)"
   additional_config: "str?"
+  ca_cert_file: "str?"
 stage: experimental
 apparmor: false

--- a/alloy/rootfs/etc/s6-overlay/s6-rc.d/init-alloy/run
+++ b/alloy/rootfs/etc/s6-overlay/s6-rc.d/init-alloy/run
@@ -12,6 +12,7 @@ mkdir -p "${CONFIG_DIR}" /data/alloy
 LOKI_URL=$(jq -r '.loki_url' "${OPTIONS_FILE}")
 LOG_LEVEL=$(jq -r '.log_level // "info"' "${OPTIONS_FILE}")
 ADDITIONAL_CONFIG=$(jq -r '.additional_config // ""' "${OPTIONS_FILE}")
+CA_CERT_FILE=$(jq -r '.ca_cert_file // ""' "${OPTIONS_FILE}")
 
 # Validate required options
 if [ -z "${LOKI_URL}" ] || [ "${LOKI_URL}" = "null" ]; then
@@ -30,12 +31,32 @@ if [ ! -d "${JOURNAL_PATH}" ]; then
     exit 1
 fi
 
+# Validate CA certificate file if provided
+if [ -n "${CA_CERT_FILE}" ] && [ "${CA_CERT_FILE}" != "null" ]; then
+    if [ ! -f "${CA_CERT_FILE}" ]; then
+        echo "ERROR: CA certificate file not found: ${CA_CERT_FILE}" >&2
+        exit 1
+    fi
+fi
+
 echo "-----------------------------------------------------------"
 echo " Grafana Alloy for Home Assistant"
 echo " Loki URL:      ${LOKI_URL}"
 echo " Journal path:  ${JOURNAL_PATH}"
 echo " Log level:     ${LOG_LEVEL}"
+if [ -n "${CA_CERT_FILE}" ] && [ "${CA_CERT_FILE}" != "null" ]; then
+    echo " CA cert file:  ${CA_CERT_FILE}"
+fi
 echo "-----------------------------------------------------------"
+
+# Build optional TLS config block for loki.write endpoint
+TLS_CONFIG_BLOCK=""
+if [ -n "${CA_CERT_FILE}" ] && [ "${CA_CERT_FILE}" != "null" ]; then
+    TLS_CONFIG_BLOCK="
+    tls_config {
+      ca_file = \"${CA_CERT_FILE}\"
+    }"
+fi
 
 # Generate Alloy config
 cat > "${CONFIG_FILE}" <<ALLOYCONFIG
@@ -49,7 +70,7 @@ logging {
 // --- Write to Loki ---
 loki.write "default" {
   endpoint {
-    url = "${LOKI_URL}"
+    url = "${LOKI_URL}"${TLS_CONFIG_BLOCK}
   }
 }
 


### PR DESCRIPTION
## Summary

- Add `ca_cert_file` option so users can provide a custom CA certificate for TLS connections to Loki (e.g., private/internal CAs like step-ca or self-signed)
- Uses Alloy's native `tls_config { ca_file }` — no system trust store changes, no downloads at startup
- Add `ssl:ro` volume mapping so the container can read certificates from the HA `/ssl/` directory

## How it works

1. User places their CA cert (PEM format) in the HA `/ssl/` directory
2. Sets `ca_cert_file: /ssl/my-ca.crt` in add-on options
3. The init script validates the file exists and injects a `tls_config` block into the generated Alloy config

## Changes

- **config.yaml**: Bump version to 1.1.0, add `ssl:ro` map, add `ca_cert_file` option + schema
- **init-alloy/run**: Read and validate `ca_cert_file`, conditionally inject `tls_config` into `loki.write` endpoint
- **DOCS.md**: Add TLS/Custom CA section with setup instructions, add troubleshooting entry
- **CHANGELOG.md**: Add 1.1.0 release entry

## Validation

- `shellcheck` passes on both shell scripts
- `yamllint` passes on all YAML files
- `hadolint` passes on Dockerfile

Closes #7